### PR TITLE
Allow specifying node version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,13 +20,17 @@ inputs:
   hosting:
     description: 'Deploy only hosting site'
     required: false
+  node-version:
+    description: 'NodeJS Version Spec of the version to use. Examples: 12.x, 10.15.1, >=10.15.0.'
+    required: false
+    default: 'current'
 runs:
   using: 'composite'
   steps:
-    - name: Use Node.js current version
+    - name: Setup Node.js 
       uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
       with:
-        node-version: current
+        node-version: ${{ inputs.node-version }}
 
     - name: Install Firebase CLI
       run: npm install -g firebase-tools


### PR DESCRIPTION
# Description

Adds a new input `node-version` which is passed to `actions/setup-node` to specify the nodejs version.
This is a bug fix because current behavior causes unexpected bugs if the project functions expect a certain nodejs version. It will fail to deploy if the version is specified in the `package.json` file

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
