### PR TITLE
Prints output of exec to the current process' stdout, stderr, & stdline

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -554,7 +554,7 @@ class OidcClient {
                 .catch(error => {
                 throw new Error(`Failed to get ID Token. \n 
         Error Code : ${error.statusCode}\n 
-        Error Message: ${error.result.message}`);
+        Error Message: ${error.message}`);
             });
             const id_token = (_a = res.result) === null || _a === void 0 ? void 0 : _a.value;
             if (!id_token) {
@@ -4071,6 +4071,11 @@ var __webpack_exports__ = {};
 
 
 const run = async () => {
+	_actions_core__WEBPACK_IMPORTED_MODULE_0__.info("This is the joinsunfish version of the code.");
+	_actions_core__WEBPACK_IMPORTED_MODULE_0__.error("IS ANYONE LISTENING TO ME?!");
+
+	process.stdout.write("HELLO?!\n");
+
 	// preflight check before starting the actions
 	const project = process.env.project;
 	if (!project) {
@@ -4082,24 +4087,53 @@ const run = async () => {
 	const config = process.env.config;
 
 	// check only deployment settings
-	let deployOnly = process.env.function === 'true' ? 'function' : '';
-	deployOnly += deployOnly === '' ? '' : ' ';
-	deployOnly += process.env.hosting === 'true' ? `hosting` : '';
+	let deployList = [];
 
-	let cmd = `firebase deploy -m ${process.env.GITHUB_SHA}`;
-	cmd += config ? ` --config ${config}` : ' ';
-	cmd += ` --project ${project}`;
-	cmd += deployOnly !== '' ? ` --only ${deployOnly}` : '';
+	if (process.env.function === 'true') {
+		deployList.push('functions');
+	}
+
+	if (process.env.hosting === 'true') {
+		deployList.push('hosting');
+	}
+
+	let args = ['deploy', '-m', process.env.GITHUB_SHA];
+
+	if (config) {
+		args.push('--config', config);
+	}
+
+	args.push('--project', project);
+
+	if (deployList.length > 0) {
+		args.push('--only', deployList.join(','));
+	}
+
+	const options = {};
+	options.listeners = {
+	  stdout: (data) => {
+		process.stdout.write(data.toString());
+	  },
+	  stderr: (data) => {
+		process.stderr.write(data.toString());
+	  },
+	  stdline: (data) => {
+		process.stdline.write(data.toString());
+	  },
+	};
 
 	try {
 		// attempt to run firebase deploy, and run with debug mode if failed
-		await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec(cmd);
+		const result = await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec("firebase", args, options);
+
 	} catch (error) {
 		_actions_core__WEBPACK_IMPORTED_MODULE_0__.error(`An error occured while deploying to Firebase: ${error}. Retrying with debug mode enabled ...`);
 
 		// attempt to run firebase deploy with debug mode
+		args.push("--debug");
+
 		try {
-			await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec(`${cmd} --debug`);
+			await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec("firebase", args, options);
 		} catch (error) {
 			_actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`An error occured while deploying to Firebase: ${error}`);
 		}

--- a/dist/index.js
+++ b/dist/index.js
@@ -4117,7 +4117,7 @@ const run = async () => {
 
 	try {
 		// attempt to run firebase deploy, and run with debug mode if failed
-		const result = await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec("firebase", args, options);
+		await _actions_exec__WEBPACK_IMPORTED_MODULE_1__.exec("firebase", args, options);
 
 	} catch (error) {
 		_actions_core__WEBPACK_IMPORTED_MODULE_0__.error(`An error occured while deploying to Firebase: ${error}. Retrying with debug mode enabled ...`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4071,11 +4071,6 @@ var __webpack_exports__ = {};
 
 
 const run = async () => {
-	_actions_core__WEBPACK_IMPORTED_MODULE_0__.info("This is the joinsunfish version of the code.");
-	_actions_core__WEBPACK_IMPORTED_MODULE_0__.error("IS ANYONE LISTENING TO ME?!");
-
-	process.stdout.write("HELLO?!\n");
-
 	// preflight check before starting the actions
 	const project = process.env.project;
 	if (!project) {
@@ -4097,13 +4092,11 @@ const run = async () => {
 		deployList.push('hosting');
 	}
 
-	let args = ['deploy', '-m', process.env.GITHUB_SHA];
+	let args = ['deploy', '-m', process.env.GITHUB_SHA, '--project', project];
 
 	if (config) {
 		args.push('--config', config);
 	}
-
-	args.push('--project', project);
 
 	if (deployList.length > 0) {
 		args.push('--only', deployList.join(','));

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ import core from '@actions/core';
 import exec from '@actions/exec';
 
 const run = async () => {
+	core.info("This is the joinsunfish version of the code.");
+
 	// preflight check before starting the actions
 	const project = process.env.project;
 	if (!project) {

--- a/src/index.js
+++ b/src/index.js
@@ -39,20 +39,20 @@ const run = async () => {
 		args.push('--only', deployList.join(','));
 	}
 
-	try {
-		const options = {};
-		options.listeners = {
-		  stdout: (data) => {
-			process.stdout.write(data.toString());
-		  },
-		  stderr: (data) => {
-			process.stderr.write(data.toString());
-		  },
-		  stdline: (data) => {
-			process.stdline.write(data.toString());
-		  },
-		};
+	const options = {};
+	options.listeners = {
+	  stdout: (data) => {
+		process.stdout.write(data.toString());
+	  },
+	  stderr: (data) => {
+		process.stderr.write(data.toString());
+	  },
+	  stdline: (data) => {
+		process.stdline.write(data.toString());
+	  },
+	};
 
+	try {
 		// attempt to run firebase deploy, and run with debug mode if failed
 		const result = await exec.exec("firebase", args, options);
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,17 @@ const run = async () => {
 	const config = process.env.config;
 
 	// check only deployment settings
-	let deployOnly = process.env.function === 'true' ? 'function' : '';
-	deployOnly += deployOnly === '' ? '' : ' ';
-	deployOnly += process.env.hosting === 'true' ? `hosting` : '';
+	let deployList = [];
+
+	if (process.env.function === 'true') {
+		deployList.push('functions');
+	}
+
+	if (process.env.hosting === 'true') {
+		deployList.push('hosting');
+	}
+
+	const deployOnly = deployList.join(',');
 
 	let cmd = `firebase deploy -m ${process.env.GITHUB_SHA}`;
 	cmd += config ? ` --config ${config}` : ' ';
@@ -25,7 +33,11 @@ const run = async () => {
 
 	try {
 		// attempt to run firebase deploy, and run with debug mode if failed
-		await exec.exec(cmd);
+		// TODO:
+		//   1. Add the current stdout and stderr as listeners to the getExecOutput listeners https://github.com/actions/toolkit/blob/main/packages/exec/src/exec.ts#L44
+		//   2. Print the result output using the relevant core function.
+		const result = await exec.getExecOutput(cmd);
+
 	} catch (error) {
 		core.error(`An error occured while deploying to Firebase: ${error}. Retrying with debug mode enabled ...`);
 

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ const run = async () => {
 
 	args.push('--project', project);
 
-	if (deployOnly.length > 0) {
+	if (deployList.length > 0) {
 		args.push('--only', deployList.join(','));
 	}
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,6 @@ import core from '@actions/core';
 import exec from '@actions/exec';
 
 const run = async () => {
-	core.info("This is the joinsunfish version of the code.");
-	core.error("IS ANYONE LISTENING TO ME?!");
-
-	process.stdout.write("HELLO?!\n");
-
 	// preflight check before starting the actions
 	const project = process.env.project;
 	if (!project) {
@@ -29,13 +24,11 @@ const run = async () => {
 		deployList.push('hosting');
 	}
 
-	let args = ['deploy', '-m', process.env.GITHUB_SHA];
+	let args = ['deploy', '-m', process.env.GITHUB_SHA, '--project', project];
 
 	if (config) {
 		args.push('--config', config);
 	}
-
-	args.push('--project', project);
 
 	if (deployList.length > 0) {
 		args.push('--only', deployList.join(','));

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ const run = async () => {
 	core.info("This is the joinsunfish version of the code.");
 	core.error("IS ANYONE LISTENING TO ME?!");
 
+	process.stdout.write("HELLO?!\n");
+
 	// preflight check before starting the actions
 	const project = process.env.project;
 	if (!project) {

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const run = async () => {
 
 	try {
 		// attempt to run firebase deploy, and run with debug mode if failed
-		const result = await exec.exec("firebase", args, options);
+		await exec.exec("firebase", args, options);
 
 	} catch (error) {
 		core.error(`An error occured while deploying to Firebase: ${error}. Retrying with debug mode enabled ...`);

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import exec from '@actions/exec';
 
 const run = async () => {
 	core.info("This is the joinsunfish version of the code.");
+	core.error("IS ANYONE LISTENING TO ME?!");
 
 	// preflight check before starting the actions
 	const project = process.env.project;


### PR DESCRIPTION
# Description

The primary purpose of this change is to add a listener to the call to `exec.exec(...)` so any output to the sub-process's stdout, stderr, and stdline are forwarded to the parent process's stdout, stderr, and stdline, effectively.

I also made some refactoring changes:
* The second parameter to `exec.exc` is the process's arguments as a list, so I converted the `cmd` creation to an array of args.
* I also converted the set of deployment options to an array of arguments, and used `.join(',')` to convert it to a single command-line argument as a comma-separated list.

Fixes #137 

## Type of change

Please delete options that are not relevant.

- [√] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [√] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [√] My changes generate no new warnings
